### PR TITLE
Clarify README setup: call setupDatabaseAndStartWatchingTables() in setUp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,35 @@ composer require imanghafoori/laravel-fast-refresh-database --dev
 ```
 
 
-### Usage:
-You should only use the trait in your test class:
+### Usage
+Add the trait to your test class and call the setup method in `setUp()` so the package can start logging insert queries and truncate only the touched tables after each test:
 
 ```php
+use Imanghafoori\DatabaseFresh\FastRefreshDatabase;
+
 class MyTest extends TestCase
 {
     use FastRefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Start watching inserts for this test process
+        $this->setupDatabaseAndStartWatchingTables();
+    }
+
     public function test_user_can_run()
     {
-    
+        // ... your test code
     }
-} 
+}
 
 ```
 
-That's it.
+Tip: Put the trait and the `setUp()` call into your base `Tests\\TestCase` to enable it for all tests.
+
+Note: An automatic hook may be added in a future update so you won't need to call the setup method manually.
 
 You may also check my other package as well:
 


### PR DESCRIPTION
- Add explicit setUp() example calling setupDatabaseAndStartWatchingTables() Include trait import in snippet
- Tip to place the setup in base Tests\TestCase
- Note about potential automatic hook in future
- Docs-only change; no runtime impact

## Summary by Sourcery

Clarify and enhance the README setup instructions for the FastRefreshDatabase package by adding an explicit setUp code example, including the trait import, a tip to apply it in the base TestCase, and a note about a future automatic hook

Documentation:
- Add explicit setUp() example calling setupDatabaseAndStartWatchingTables() in README
- Include trait import snippet in the usage example
- Add tip to place the trait and setup call in the base Tests\\TestCase
- Note potential future automatic hook to remove manual setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README Usage section to clarify adding the trait and invoking setup in setUp() to log inserts and truncate only touched tables per test.
  - Expanded code example with import, trait usage, and setup flow; included a placeholder comment in the test.
  - Added Tip to place the trait and setUp() call in a base Tests\TestCase for global enablement.
  - Added Note about a potential future automatic hook to remove manual setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->