### PR TITLE
remove `@before` annotation and implement new solution for automatically load watcher

### DIFF
--- a/src/FastRefreshDatabase.php
+++ b/src/FastRefreshDatabase.php
@@ -11,11 +11,9 @@ trait FastRefreshDatabase
     use CanConfigureMigrationCommands;
 
     /**
-     * PHPUnit hook to start watching insert queries before each test.
-     *
-     * @before
+     * Start watching insert queries before each test.
      */
-    public function setupDatabaseAndStartWatchingTables(): void
+    public function setUpFastRefreshDatabase(): void
     {
         $this->beforeFastRefreshDatabase();
 
@@ -110,7 +108,6 @@ trait FastRefreshDatabase
         return property_exists($this, 'connectionsToUnseed')
             ? $this->connectionsToUnseed : [null];
     }
-
 
     /**
      * Perform any work that should take place before the database has started refreshing.


### PR DESCRIPTION
- remove `@before` annotation due to conflict with initializing laravel testing
- rename `setupDatabaseAndStartWatchingTables` to `setUpFastRefreshDatabase` for auto calling by laravel (Use as before but without `@before`) [Source](https://github.com/laravel/framework/blob/d91db74b1c550a5fe29665cb90928fe3380335e1/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTestCaseLifecycle.php#L233)
#### fix this [issue](https://github.com/imanghafoori1/laravel-fast-refresh-database/issues/5)

## Summary by Sourcery

Remove the PHPUnit @before annotation and adopt Laravel’s testing lifecycle method naming to auto-start table change watching

Bug Fixes:
- Remove @before annotation to resolve conflicts with Laravel test initialization

Enhancements:
- Rename setupDatabaseAndStartWatchingTables to setUpFastRefreshDatabase for automatic invocation by Laravel’s test framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated method naming conventions in the database refresh utility to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->